### PR TITLE
fix: Inline Lock and RingBuffer operators

### DIFF
--- a/src/RTOScppLock.h
+++ b/src/RTOScppLock.h
@@ -35,7 +35,7 @@ class Lock {
   virtual bool give() { return xSemaphoreGive(_handle); }
 };
 
-bool operator==(const QueueSetMemberHandle_t& queue_set_member, const Lock& semaphore) {
+inline bool operator==(const QueueSetMemberHandle_t& queue_set_member, const Lock& semaphore) {
   return queue_set_member == semaphore._handle;
 }
 

--- a/src/RTOScppRingBuffer.h
+++ b/src/RTOScppRingBuffer.h
@@ -29,7 +29,8 @@ class RingBufBase {
   RingbufHandle_t getHandle() { return _handle; }
 };
 
-bool operator==(const QueueSetMemberHandle_t& queue_set_member, const RingBufBase& ring_buffer) {
+inline bool operator==(const QueueSetMemberHandle_t& queue_set_member,
+                       const RingBufBase& ring_buffer) {
   return xRingbufferCanRead(ring_buffer._handle, queue_set_member);
 }
 


### PR DESCRIPTION
Inline operators to get rid of multiple definitions errors.